### PR TITLE
add argument spec and automated docs

### DIFF
--- a/.aar-doc.yml
+++ b/.aar-doc.yml
@@ -1,0 +1,49 @@
+output_template: |
+  <!-- BEGIN_ANSIBLE_DOCS -->
+
+  # Ansible role {{ metadata.galaxy_info.author }}.{{ metadata.galaxy_info.role_name }}
+
+  {{ metadata.galaxy_info.description }}
+
+  ## Supported Operating Systems
+
+  {%- for platform in metadata.galaxy_info.platforms %}
+  - {{ platform.name }}
+    {%- if "versions" in platform %}
+    - {{ platform.versions | default([]) | join(', ') }}
+    {%- endif %}
+  {%- endfor %}
+
+  ## Role Variables
+  {% for entrypoint in argument_specs.keys() %}
+  {%- set path, options=entrypoint_options[entrypoint][0] -%}
+  {%- for name, details in options.items() |sort() %}
+  - `{{ name }}`
+    - Default: `{{ details.display_default }}`
+    - Description: {{ details.display_description }}
+    - Type: {{ details.display_type }}
+    - Required: {{ details.display_required }}
+  {%- endfor %}
+  {%- endfor %}
+
+  ## Dependencies
+
+  {%- if ("dependencies" in metadata) and (metadata.dependencies | length > 0) %}
+  {%- for dependency in metadata.dependencies %}
+  - {{ dependency }}
+  {%- endfor %}
+  {%- else %}
+
+  None.
+  {%- endif %}
+
+  ## Example Playbook
+
+  ```
+  - hosts: all
+    roles:
+      - name: {{ role }}
+  ```
+
+
+  <!-- END_ANSIBLE_DOCS -->

--- a/.github/workflows/roles-readme.yml
+++ b/.github/workflows/roles-readme.yml
@@ -1,0 +1,45 @@
+---
+name: create roles readme
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches: [master]
+    paths:
+      - 'meta/argument_specs.yml'
+      - 'meta/main.yml'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'meta/argument_specs.yml'
+      - 'meta/main.yml'
+
+jobs:
+  readme:
+    name: create roles readme
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+
+      - name: Install aar_doc
+        run: pip3 install aar_doc
+
+      - name: Run aar_doc
+        run: aar_doc --config-file .aar-doc.yml . markdown
+
+      - name: Output diff
+        run: git diff README.md
+
+      - name: Push README
+        if: github.event_name != 'pull_request'
+        uses: github-actions-x/commit@v2.9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'update readme'
+          files: README.md
+          rebase: true

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ This role installs and configures HAProxy on hosts and also allows changing the 
   - Type: list
   - Required: no
 - `haproxy_backends`
-  - Default: `[{"name": null, "default": "myHttpBackend", "type": "str", "description": "", "connect_timeout": {"default": "10s", "type": "str", "description": ""}, "server_timeout": {"default": "1m", "type": "str", "description": ""}, "mode": {"default": "http", "type": "str", "description": ""}, "servers": [{"name": null, "default": "my-server-1", "type": "str", "description": "", "address": {"default": "192.168.0.3", "type": "str", "description": ""}, "port": {"default": 80, "type": "str", "description": ""}}, {"name": null, "default": "my-server-2", "type": "str", "description": "", "address": {"default": "192.168.0.3", "type": "str", "description": ""}, "port": {"default": 80, "type": "str", "description": ""}}], "options": ["httplog", "http-check"]}]`
+  - Default: ``
   - Description: List of backends
-  - Type: list
+  - Type: list of 'dict'
   - Required: no
 - `haproxy_configuration_no_log`
   - Default: `true`
@@ -78,9 +78,9 @@ This role installs and configures HAProxy on hosts and also allows changing the 
   - Type: list
   - Required: no
 - `haproxy_frontends`
-  - Default: `[{"name": null, "default": "myHttpFrontend", "type": "str", "description": "", "binds": {"default": null, "type": "str", "description": "", "address": {"default": "127.0.0.1", "type": "str", "description": ""}, "port": {"default": 80, "type": "str", "description": ""}}, "mode": {"default": "http", "type": "str", "description": ""}, "default_backend": {"default": "myHttpBackend", "type": "str", "description": ""}, "client_timeout": {"default": "30s", "type": "str", "description": ""}, "options": ["httplog"]}]`
+  - Default: ``
   - Description: List of frontends
-  - Type: list
+  - Type: list of 'dict'
   - Required: no
 - `haproxy_global_chroot`
   - Default: `/var/lib/haproxy`

--- a/README.md
+++ b/README.md
@@ -1,82 +1,132 @@
-# ansible-role-haproxy
+<!-- BEGIN_ANSIBLE_DOCS -->
+
+# Ansible role telekom_mms.haproxy
 
 This role installs and configures HAProxy on hosts and also allows changing the distribution of backend servers of HAProxy backends.
 
-## Variables
+## Supported Operating Systems
+- EL
+  - all
+- Debian
+  - all
 
-| Variable                                   | Required | Default                | Description
-|--------------------------------------------|----------|------------------------|------------
-| **configuration**
-| haproxy_global_stats_socket                | yes      | /var/lib/haproxy/stats | Set socket path
-| haproxy_global_stats_socket_level          | no       |                        | Set level of socket. Available options are `user`, `operator`, `admin`. Operator is set by default if nothing is set. [See HAProxy documentation for mor info.](https://www.haproxy.com/documentation/hapee/latest/onepage/#5.1-level)
-| haproxy_global_chroot                      | yes      | /var/lib/haproxy       |
-| haproxy_global_user                        | yes      | haproxy                | HAProxy User
-| haproxy_global_group                       | yes      | haproxy                | HAProxy Group
-| haproxy_global_vars                        | no       |                        | List of variables for global configuration part of HAProxy
-| haproxy_default_stats                      | yes      | enable                 | Enable or Disable Stats
-| haproxy_default_timeout_queue              | yes      | 1m                     |
-| haproxy_default_timeout_connect            | yes      | 10s                    |
-| haproxy_default_timeout_client             | yes      | 1m                     |
-| haproxy_default_timeout_server             | yes      | 1m                     |
-| haproxy_default_timeout_check              | yes      | 10s                    |
-| haproxy_default_vars                       | no       |                        | List of variables for default configuration part of HAProxy
-| haproxy_rsyslog_configuration_file         | no       | RedHat: /etc/rsyslog.d/haproxy.conf<br/> Debian: /etc/rsyslog.d/49-haproxy.conf | rsyslog configuration file for haproxy
-| haproxy_rsyslog_module_regex               | no       | RedHat: ^#(\$ModLoad imudp)<br/> Debian: ^#(module\(load="imudp"\)) | regex to activate module imudp
-| haproxy_rsyslog_udp_server_regex           | no       | RedHat: ^#(\$UDPServerRun 514)<br/> Debian: ^#(input\(type="imudp" port="514"\)) | regex to activate udp server on port 514
-| haproxy_configuration_no_log               | no       | true | Do not show rendered template output on creation
-| **userlist configuration**
-| haproxy_user_list | no | | List of userlists
-| &ensp;name        | yes | | Name of the userlist
-| &ensp;users       | yes | | List of users
-| &ensp;name        | yes | | Name of the user
-| &ensp;pwhash      | yes | | Hashed password from according user. [Click here to see how to create a hash.](https://www.haproxy.com/documentation/haproxy-configuration-tutorials/authentication/basic-authentication/#hash-passwords-in-the-userlist)
-| **haproxy custom configuration**
-| haproxy_custom_config | no | | Custom haproxy configuration
-| **frontend configuration**
-| haproxy_frontends                          | yes      |                        | List of frontends
-| &ensp;name                                 | yes      | myHttpFrontend         | Name of the frontend
-| &ensp;binds                                | yes      |                        |
-| &ensp; &ensp;address                       | yes      | 127.0.0.1              | Frontend address
-| &ensp; &ensp;port                          | yes      | 80                     | Frontend port
-| &ensp; &ensp;param                         | no       |                        | Frontend params. Eg. "ssl cert /etc/haproxy/ssl"
-| &ensp;mode                                 | yes      | http                   | Mode of frontend http, tcp
-| &ensp;default_backend                      | yes      | myHttpBackend          | Default backend of frontend
-| &ensp;client_timeout                       | yes      | 30s                    |
-| &ensp;options                              | no       | httplog                | Options of frontend
-| &ensp;vars                                 | no       |                        | List of variables for frontend
-| &ensp;comments                             | no       |                        | Comment for frontend
-| **backend configuration**
-| haproxy_backends                           | yes      |                        |
-| &ensp;name                                 | yes      | myHttpBackend          | Name of backend
-| &ensp;connect_timeout                      | yes      | 10s                    |
-| &ensp;server_timeout                       | yes      | 1m                     |
-| &ensp;balance_method                       | no       | roundrobin             | Method for balancing. See [HAProxy documentation for options](https://cbonte.github.io/haproxy-dconv/2.0/configuration.html#balance)
-| &ensp;mode                                 | yes      |                        | Mode of backend: http, tcp
-| &ensp;servers                              | yes      |                        | List of backend servers
-| &ensp; &ensp;name                          | yes      | my-server-1            | Name of backend server
-| &ensp; &ensp;address                       | yes      | 192.168.0.3            | IP address of backend server
-| &ensp; &ensp;port                          | yes      | 80                     | Port of backend server
-| &ensp; &ensp;options                       | no       |                        | Options for backend servers eg. "check cookie a6ae174841dfc53aaede3a29a21242c0"
-| &ensp;options                              | no       | httplog, http-check    | Options of backend
-| &ensp;aclist                               | no       |                        | Generates Multiple instances of the same ACL with different values (usable e.g for IP-Whitelists)
-| &ensp; &ensp;name                     | yes      |                        | Name of the ACL
-| &ensp; &ensp;match                    | yes      |                        | Matching method of the item (e.g. `src` or `hdr(X-Forwarded-For)`)
-| &ensp; &ensp;vars                     | yes      |                        | Array of the ACL items
-| &ensp; &ensp;use_backend              | no       |                        | Define a backend to use when condition for ACL matches.
-| &ensp; &ensp; &ensp;name              | yes      |                        | Name of the backend to use.
-| &ensp; &ensp; &ensp;operation         | no       | if                     | Operation for condition. Possible values are `if` and `unless`.
-| &ensp; &ensp; &ensp;check_acl         | yes      |                        | List of ACLs to check. If a list is given the ACLs will be concatenated with AND
-| &ensp;vars                            | no       |                        | List of variables for backend.
-| &ensp;comments                        | no       |                        | Comment for backend
-| **distribution config/change**
-| haproxy_distribution_lb_change             |          | false                  | Adjust distribution of HAProxy backend servers.
-| haproxy_distribution_lb_backend_state      | yes      |                        | Set server into state [drain,enabled,disabled]
-| haproxy_distribution_lb_backend            | yes      |                        | Name of the backend which should be changed.
-| haproxy_distribution_lb_inventory_group    | yes      |                        | Inventory groupname which hold the hosts on which the backend servers should be changed.
-| haproxy_distribution_lb_backend_drain_wait | no       | 60                     | Seconds to wait for drain of connections before changing state to MAINT|disabled
-| haproxy_distribution_lb_backend_fail_on_not_found | no | false | Fail task if server cant be found in backend
-| **maintenance pages**
-| haproxy_maintenance_pages_file_path        | no       |                        | If defined, role creates maintenance pages from this path on system
+## Role Variables
+
+- `haproxy_backend_vars`
+  - Default: ``
+  - Description: List of backend variables
+  - Type: list
+  - Required: no
+- `haproxy_backends`
+  - Default: `[{"name": null, "default": "myHttpBackend", "type": "str", "description": "", "connect_timeout": {"default": "10s", "type": "str", "description": ""}, "server_timeout": {"default": "1m", "type": "str", "description": ""}, "mode": {"default": "http", "type": "str", "description": ""}, "servers": [{"name": null, "default": "my-server-1", "type": "str", "description": "", "address": {"default": "192.168.0.3", "type": "str", "description": ""}, "port": {"default": 80, "type": "str", "description": ""}}, {"name": null, "default": "my-server-2", "type": "str", "description": "", "address": {"default": "192.168.0.3", "type": "str", "description": ""}, "port": {"default": 80, "type": "str", "description": ""}}], "options": ["httplog", "http-check"]}]`
+  - Description: List of backends
+  - Type: list
+  - Required: no
+- `haproxy_configuration_no_log`
+  - Default: `true`
+  - Description: Do not show rendered template output on creation
+  - Type: bool
+  - Required: no
+- `haproxy_default_stats`
+  - Default: `enable`
+  - Description: Enable or disable stats
+  - Type: str
+  - Required: no
+- `haproxy_default_timeout_check`
+  - Default: `10s`
+  - Description: Set additional check timeout, but only after a connection has been already established.
+  - Type: str
+  - Required: no
+- `haproxy_default_timeout_client`
+  - Default: `1m`
+  - Description: Set the maximum inactivity time on the client side.
+  - Type: str
+  - Required: no
+- `haproxy_default_timeout_connect`
+  - Default: `10s`
+  - Description: Set the maximum time to wait for a connection attempt to a server to succeed.
+  - Type: str
+  - Required: no
+- `haproxy_default_timeout_queue`
+  - Default: `1m`
+  - Description: Set the maximum time to wait in the queue for a connection slot to be free
+  - Type: str
+  - Required: no
+- `haproxy_default_timeout_server`
+  - Default: `1m`
+  - Description: Set the maximum inactivity time on the server side.
+  - Type: str
+  - Required: no
+- `haproxy_default_vars`
+  - Default: ``
+  - Description: List of variables for default configuration part of HAProxy
+  - Type: list
+  - Required: no
+- `haproxy_distribution_lb_backend_drain_wait`
+  - Default: `60`
+  - Description: Seconds to wait for drain of connections before changing state to MAINT|disabled
+  - Type: int
+  - Required: no
+- `haproxy_distribution_lb_change`
+  - Default: `false`
+  - Description: Adjust distribution of HAProxy backend servers.
+  - Type: bool
+  - Required: no
+- `haproxy_frontend_vars`
+  - Default: ``
+  - Description: List of frontend variables
+  - Type: list
+  - Required: no
+- `haproxy_frontends`
+  - Default: `[{"name": null, "default": "myHttpFrontend", "type": "str", "description": "", "binds": {"default": null, "type": "str", "description": "", "address": {"default": "127.0.0.1", "type": "str", "description": ""}, "port": {"default": 80, "type": "str", "description": ""}}, "mode": {"default": "http", "type": "str", "description": ""}, "default_backend": {"default": "myHttpBackend", "type": "str", "description": ""}, "client_timeout": {"default": "30s", "type": "str", "description": ""}, "options": ["httplog"]}]`
+  - Description: List of frontends
+  - Type: list
+  - Required: no
+- `haproxy_global_chroot`
+  - Default: `/var/lib/haproxy`
+  - Description: Changes current directory to  specified value and performs a chroot() there before dropping privilege
+  - Type: str
+  - Required: no
+- `haproxy_global_group`
+  - Default: `haproxy`
+  - Description: HaProxy Group
+  - Type: str
+  - Required: no
+- `haproxy_global_stats_socket`
+  - Default: `/var/lib/haproxy/stats`
+  - Description: Set socket path
+  - Type: str
+  - Required: no
+- `haproxy_global_user`
+  - Default: `haproxy`
+  - Description: HaProxy User
+  - Type: str
+  - Required: no
+- `haproxy_global_vars`
+  - Default: ``
+  - Description: List of variables for global configuration part of HAProxy
+  - Type: list
+  - Required: no
+- `haproxy_user_list`
+  - Default: ``
+  - Description: List of userlists
+  - Type: list
+  - Required: no
+
+## Dependencies
+
+None.
+
+## Example Playbook
+
+```
+- hosts: all
+  roles:
+    - name: ansible-role-haproxy
+```
+
+
+<!-- END_ANSIBLE_DOCS -->
 
 ## Usage
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,33 +15,10 @@ haproxy_default_vars: []
 
 haproxy_user_list: []
 
-haproxy_frontends:
-  - name: myHttpFrontend
-    binds:
-      address: 127.0.0.1
-      port: 80
-    mode: http
-    default_backend: myHttpBackend
-    client_timeout: 30s
-    options:
-      - httplog
+haproxy_frontends: []
 haproxy_frontend_vars: []
 
-haproxy_backends:
-  - name: myHttpBackend
-    connect_timeout: 10s
-    server_timeout: 1m
-    mode: http
-    servers:
-      - name: "my-server-1"
-        address: "192.168.0.3"
-        port: 80
-      - name: "my-server-2"
-        address: "192.168.0.3"
-        port: 80
-    options:
-      - httplog
-      - http-check
+haproxy_backends: []
 haproxy_backend_vars: []
 
 haproxy_distribution_lb_change: false

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -62,38 +62,10 @@ argument_specs:
         description: List of userlists
       haproxy_frontends:
         type: list
+        elements: dict
         description: List of frontends
-        default:
-          - name:
-            default: myHttpFrontend
-            type: str
-            description: ''
-            binds:
-              default:
-              type: str
-              description: ''
-              address:
-                default: 127.0.0.1
-                type: str
-                description: ''
-              port:
-                default: 80
-                type: str
-                description: ''
-            mode:
-              default: http
-              type: str
-              description: ''
-            default_backend:
-              default: myHttpBackend
-              type: str
-              description: ''
-            client_timeout:
-              default: 30s
-              type: str
-              description: ''
-            options:
-              - httplog
+        default: []
+
       haproxy_frontend_vars:
         default: []
         type: list
@@ -101,52 +73,10 @@ argument_specs:
 
       haproxy_backends:
         type: list
+        elements: dict
         description: List of backends
-        default:
-          - name:
-            default: myHttpBackend
-            type: str
-            description: ''
-            connect_timeout:
-              default: 10s
-              type: str
-              description: ''
-            server_timeout:
-              default: 1m
-              type: str
-              description: ''
-            mode:
-              default: http
-              type: str
-              description: ''
-            servers:
-              - name:
-                default: my-server-1
-                type: str
-                description: ''
-                address:
-                  default: 192.168.0.3
-                  type: str
-                  description: ''
-                port:
-                  default: 80
-                  type: str
-                  description: ''
-              - name:
-                default: my-server-2
-                type: str
-                description: ''
-                address:
-                  default: 192.168.0.3
-                  type: str
-                  description: ''
-                port:
-                  default: 80
-                  type: str
-                  description: ''
-            options:
-              - httplog
-              - http-check
+        default: []
+
       haproxy_backend_vars:
         default: []
         type: list

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -16,7 +16,7 @@ argument_specs:
       haproxy_global_user:
         default: haproxy
         type: str
-        description: HaProxy User
+        description: HAProxy User
       haproxy_global_group:
         default: haproxy
         type: str

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -1,0 +1,168 @@
+---
+argument_specs:
+  main:
+    short_description: The main entry point for the haproxy role.
+    version_added: 1.0.0
+    options:
+      haproxy_global_stats_socket:
+        default: /var/lib/haproxy/stats
+        type: str
+        description: Set socket path
+      haproxy_global_chroot:
+        default: /var/lib/haproxy
+        type: str
+        description: Changes current directory to  specified value and performs a
+          chroot() there before dropping privilege
+      haproxy_global_user:
+        default: haproxy
+        type: str
+        description: HaProxy User
+      haproxy_global_group:
+        default: haproxy
+        type: str
+        description: HaProxy Group
+      haproxy_global_vars:
+        default: []
+        type: list
+        description: List of variables for global configuration part of HAProxy
+      haproxy_default_stats:
+        default: enable
+        type: str
+        description: Enable or disable stats
+      haproxy_default_timeout_queue:
+        default: 1m
+        type: str
+        description: Set the maximum time to wait in the queue for a connection slot
+          to be free
+      haproxy_default_timeout_connect:
+        default: 10s
+        type: str
+        description: Set the maximum time to wait for a connection attempt to a server
+          to succeed.
+      haproxy_default_timeout_client:
+        default: 1m
+        type: str
+        description: Set the maximum inactivity time on the client side.
+      haproxy_default_timeout_server:
+        default: 1m
+        type: str
+        description: Set the maximum inactivity time on the server side.
+      haproxy_default_timeout_check:
+        default: 10s
+        type: str
+        description: Set additional check timeout, but only after a connection has
+          been already established.
+      haproxy_default_vars:
+        default: []
+        type: list
+        description: List of variables for default configuration part of HAProxy
+      haproxy_user_list:
+        default: []
+        type: list
+        description: List of userlists
+      haproxy_frontends:
+        type: list
+        description: List of frontends
+        default:
+          - name:
+            default: myHttpFrontend
+            type: str
+            description: ''
+            binds:
+              default:
+              type: str
+              description: ''
+              address:
+                default: 127.0.0.1
+                type: str
+                description: ''
+              port:
+                default: 80
+                type: str
+                description: ''
+            mode:
+              default: http
+              type: str
+              description: ''
+            default_backend:
+              default: myHttpBackend
+              type: str
+              description: ''
+            client_timeout:
+              default: 30s
+              type: str
+              description: ''
+            options:
+              - httplog
+      haproxy_frontend_vars:
+        default: []
+        type: list
+        description: List of frontend variables
+
+      haproxy_backends:
+        type: list
+        description: List of backends
+        default:
+          - name:
+            default: myHttpBackend
+            type: str
+            description: ''
+            connect_timeout:
+              default: 10s
+              type: str
+              description: ''
+            server_timeout:
+              default: 1m
+              type: str
+              description: ''
+            mode:
+              default: http
+              type: str
+              description: ''
+            servers:
+              - name:
+                default: my-server-1
+                type: str
+                description: ''
+                address:
+                  default: 192.168.0.3
+                  type: str
+                  description: ''
+                port:
+                  default: 80
+                  type: str
+                  description: ''
+              - name:
+                default: my-server-2
+                type: str
+                description: ''
+                address:
+                  default: 192.168.0.3
+                  type: str
+                  description: ''
+                port:
+                  default: 80
+                  type: str
+                  description: ''
+            options:
+              - httplog
+              - http-check
+      haproxy_backend_vars:
+        default: []
+        type: list
+        description: List of backend variables
+
+      haproxy_distribution_lb_change:
+        default: false
+        type: bool
+        description: Adjust distribution of HAProxy backend servers.
+      haproxy_distribution_lb_backend_drain_wait:
+        default: 60
+        type: int
+        description: Seconds to wait for drain of connections before changing state
+          to MAINT|disabled
+
+      haproxy_configuration_no_log:
+        default: true
+        type: bool
+        description: Do not show rendered template output on creation

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,7 @@
 galaxy_info:
   role_name: haproxy
   author: telekom_mms
-  description: Install and configure HAProxy on different operation systems
+  description: This role installs and configures HAProxy on hosts and also allows changing the distribution of backend servers of HAProxy backends.
   license: GPLv3
   min_ansible_version: "2.9"
   galaxy_tags: [haproxy]


### PR DESCRIPTION
This PR adds several things:

- an argument spec (https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_reuse_roles.html#role-argument-validation) to be used to validate if your role has the required params
- building upon the argument spec:
  - an automatically created and updated readme (with https://github.com/telekom-mms/Automated-Ansible-Role-Documentation) 
    - the readme vars are created from the argument_spec.yml, so every new default-variable has to be added there to land in the readme 
    - the format of the readme can be adjusted (e.g. if you want to keep the table format)
  - a github action to automatically update the readme

Let me know what you think